### PR TITLE
PDFのリンク切れを修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@ openBDに掲載する書誌情報・書影は版元ドットコムが収集し�
 <h3>openBDセミナーを開催しました</h3>
 
 <a href="/pdf/openBD_doc_20170123.pdf">全体の配布資料</a><br>
-<a href="/api20170123.pdf">カーリル（吉本）のプレゼン資料</a><br>
+<a href="/pdf/api20170123.pdf">カーリル（吉本）のプレゼン資料</a><br>
 <a href="pdf/openBD20170123.pdf">イベントのチラシ</a><br><br>
 
 ●日時　2017年1月23日（月）<br>


### PR DESCRIPTION
「カーリル（吉本）のプレゼン資料」のPDFがリンク切れのようでした。こちらの修正でいかがでしょうか。